### PR TITLE
Add managerial dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ import Login from "./routes/login/login";
 import { Ativos } from "./routes/telas/ativos";
 import { AuthGuard } from "@/components/authGuard";
 import { Carousel } from "./routes/telas/carousel";
-import  DashBoardGerencial  from "./routes/realTime/page";
+import ResumosPage from "./routes/resumos/page";
 function App() {
     const msalInstance = new PublicClientApplication(config);
 
@@ -47,7 +47,7 @@ const router = createBrowserRouter(
             { path: "ativos", element: <Ativos /> },
             { path: "inventory", element: <h1 className="title">Inventory</h1> },
             { path: "settings", element: <h1 className="title">Settings</h1> },
-            { path: "resumos", element: <DashBoardGerencial/>},
+            { path: "resumos", element: <ResumosPage /> },
           ]
         }
       ]

--- a/src/components/monitoramento/dashboardGerencial.jsx
+++ b/src/components/monitoramento/dashboardGerencial.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { useDashboardGerencial } from '@/hooks/useDashboardGerencial';
+import { GraficoDeBarras } from './graficos/graficoDeBarras';
+import { GraficoDePizza } from './graficos/graficoDePizza';
+import { GraficoDeColunas } from './graficos/graficoDeColunas';
+
+const InfoCard = ({ label, value }) => (
+  <div className="bg-card-bg p-4 rounded-xl shadow-md text-center">
+    <p className="text-lg">{label}</p>
+    <h2 className="text-2xl text-text-bold-color font-bold">{value}</h2>
+  </div>
+);
+
+const ArquivoItem = ({ arquivo }) => (
+  <div className="border-b border-gray-600 py-2 flex flex-col">
+    <span className="text-yellow-300 text-sm font-semibold">{arquivo.industria || '—'}</span>
+    <span className="text-gray-400 text-xs">{arquivo.data}</span>
+    <span className="text-green-400 text-sm">R$ {parseFloat(arquivo.valor || 0).toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</span>
+    <span className="text-blue-300 text-sm">{arquivo.quantidade} cab.</span>
+  </div>
+);
+
+const DashboardGerencial = () => {
+  const { info, arquivos, barChartData, pieChartData, columnChartData } = useDashboardGerencial();
+
+  return (
+    <div className="bg-background text-white min-h-full p-4 flex flex-col gap-6">
+      <h1 className="text-2xl font-bold text-center">Resumo Gerencial</h1>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <InfoCard label="Arquivos" value={info.totalFiles} />
+        <InfoCard label="Cabeças" value={info.totalHeads} />
+        <InfoCard label="Tokens" value={info.totalToken} />
+        <InfoCard label="Valor" value={`R$ ${parseFloat(info.currentValue || 0).toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`} />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="bg-card-bg p-4 rounded-xl">
+          <h3 className="text-center mb-2">Últimos Arquivos</h3>
+          <div className="overflow-y-auto max-h-60 space-y-2">
+            {arquivos.slice(0,5).map((arq, i) => <ArquivoItem key={i} arquivo={arq} />)}
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-4">
+          <div className="bg-card-bg p-4 rounded-xl">
+            <h4 className="text-center mb-2">Negócios por Frete</h4>
+            <GraficoDeBarras data={barChartData} />
+          </div>
+          <div className="bg-card-bg p-4 rounded-xl">
+            <h4 className="text-center mb-2">Negócios por Categoria</h4>
+            <GraficoDePizza data={pieChartData} />
+          </div>
+          <div className="bg-card-bg p-4 rounded-xl">
+            <h4 className="text-center mb-2">Negócios por Estado</h4>
+            <GraficoDeColunas data={columnChartData} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardGerencial;

--- a/src/hooks/useDashboardGerencial.jsx
+++ b/src/hooks/useDashboardGerencial.jsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+
+export const useDashboardGerencial = () => {
+  const [info, setInfo] = useState({ totalFiles: 0, totalHeads: 0, totalToken: 0, currentValue: 0 });
+  const [arquivos, setArquivos] = useState([]);
+  const [barChartData, setBarChartData] = useState([]);
+  const [pieChartData, setPieChartData] = useState([]);
+  const [columnChartData, setColumnChartData] = useState([]);
+
+  const fetchData = async () => {
+    try {
+      const [calculoDados, arquivosDados, negociosDados] = await Promise.all([
+        fetch('https://pecuaria.datagro.com/backoffice-pec/api/v1/dashboard/calculo?obter=dados').then(res => res.json()),
+        fetch('https://pecuaria.datagro.com/backoffice-pec/api/v1/dashboard/realtime?obter=arquivo').then(res => res.json()),
+        fetch('https://pecuaria.datagro.com/backoffice-pec/api/v1/dashboard/realtime?obter=negocios-hoje').then(res => res.json())
+      ]);
+
+      const datahoraDados = Object.keys(calculoDados.resultados || {});
+      if (datahoraDados.length > 0) {
+        const latestKey = datahoraDados[datahoraDados.length - 1];
+        const dados = calculoDados.resultados[latestKey];
+        setInfo({
+          totalFiles: dados.arquivos ?? 0,
+          totalHeads: dados.cabecas ?? 0,
+          totalToken: dados.tokens ?? 0,
+          currentValue: dados.total ?? 0
+        });
+      }
+
+      const datahoraArquivos = Object.keys(arquivosDados.resultado || {});
+      if (datahoraArquivos.length > 0) {
+        setArquivos(Object.values(arquivosDados.resultado));
+      }
+
+      if (negociosDados && negociosDados.retorno) {
+        const { cif, fob, boi, vaca, novilha, ufs } = negociosDados.retorno;
+        setBarChartData([
+          { x: 'CIF', value: cif },
+          { x: 'FOB', value: fob }
+        ]);
+        setPieChartData([
+          { x: 'Boi', value: boi },
+          { x: 'Vaca', value: vaca },
+          { x: 'Novilha', value: novilha }
+        ]);
+        setColumnChartData(
+          Object.keys(ufs).map(key => ({ x: key, value: ufs[key] }))
+        );
+      }
+    } catch (error) {
+      console.error('Erro ao buscar dados:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 2 * 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return { info, arquivos, barChartData, pieChartData, columnChartData };
+};

--- a/src/routes/resumos/page.jsx
+++ b/src/routes/resumos/page.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import DashboardGerencial from '@/components/monitoramento/dashboardGerencial';
+
+export const ResumosPage = () => <DashboardGerencial />;
+
+export default ResumosPage;


### PR DESCRIPTION
## Summary
- add DashboardGerencial component
- fetch realtime data via new `useDashboardGerencial` hook
- expose new page in `src/routes/resumos`
- hook up `/resumos` route in App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687bc6a439c48330af4697d8fe696398