### PR TITLE
Improve culture-specific dashboards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import { ThemeProvider } from "@/contexts/theme-context";
+import { CultureProvider } from "@/contexts/culture-context";
 import { MsalProvider } from "@azure/msal-react";
 import { PublicClientApplication } from "@azure/msal-browser";
 import { config } from "./utils/config";
@@ -20,6 +21,10 @@ import { Ativos } from "./routes/telas/ativos";
 import { AuthGuard } from "@/components/authGuard";
 import { Carousel } from "./routes/telas/carousel";
 import ResumosPage from "./routes/resumos/page";
+import BoiDashboardPage from '@/pages/dashboard/boi';
+import MilhoDashboardPage from '@/pages/dashboard/milho';
+import LeiteDashboardPage from '@/pages/dashboard/leite';
+import EtanolDashboardPage from '@/pages/dashboard/etanol';
 function App() {
     const msalInstance = new PublicClientApplication(config);
 
@@ -45,6 +50,10 @@ const router = createBrowserRouter(
             { path: "distribuicao", element: <DistribuicaoPage /> },
             { path: "quantidades", element: <DashboardQts /> },
             { path: "ativos", element: <Ativos /> },
+            { path: "dashboard/boi", element: <BoiDashboardPage /> },
+            { path: "dashboard/milho", element: <MilhoDashboardPage /> },
+            { path: "dashboard/leite", element: <LeiteDashboardPage /> },
+            { path: "dashboard/etanol", element: <EtanolDashboardPage /> },
             { path: "inventory", element: <h1 className="title">Inventory</h1> },
             { path: "settings", element: <h1 className="title">Settings</h1> },
             { path: "resumos", element: <ResumosPage /> },
@@ -63,10 +72,11 @@ const router = createBrowserRouter(
 
     return (
         <MsalProvider instance={msalInstance}>
-
+        <CultureProvider>
         <ThemeProvider theme="dark">
             <RouterProvider router={router} />
         </ThemeProvider>
+        </CultureProvider>
         </MsalProvider>
     );
 }

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useContext } from 'react'
 import { cn } from '@/utils/cn'
 import { navbarLinks } from '@/constants';
 import { ChevronsLeft } from 'lucide-react';
@@ -8,10 +8,12 @@ import milho from '@/assets/pins/MILHO.png';
 import leite from '@/assets/pins/LEITE.png';
 
 import PropTypes from 'prop-types';
-import { Link, NavLink } from 'react-router-dom';
+import { Link, NavLink, useNavigate } from 'react-router-dom';
+import { CultureContext } from '@/contexts/culture-context';
 
 export const Sidebar = forwardRef(({ collapsed }, ref) => {
-
+  const { setCulture } = useContext(CultureContext);
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = React.useState(false);
   
   return (
@@ -32,22 +34,22 @@ export const Sidebar = forwardRef(({ collapsed }, ref) => {
         <>          
           <div className=' flex flex-1 items-center  overflow-x-auto'>
             <button
-              onClick={() => setIsOpen(!isOpen)}>
+              onClick={() => { setCulture('boi'); navigate('/dashboard/boi'); setIsOpen(!isOpen); }}>
                 <img src={boi} className='h-12 w-12 hover:w-20 hover:h-20' />
               </button>
-              
+
               <button
-              onClick={() => setIsOpen(!isOpen)}>
+              onClick={() => { setCulture('milho'); navigate('/dashboard/milho'); setIsOpen(!isOpen); }}>
                 <img src={milho} className='w-8 h-12 hover:w-16 hover:h-20' />
               </button>
 
               <button
-              onClick={() => setIsOpen(!isOpen)}>
+              onClick={() => { setCulture('etanol'); navigate('/dashboard/etanol'); setIsOpen(!isOpen); }}>
                 <img src={etanol} className='w-12 h-12 hover:w-20 hover:h-20' />
               </button>
 
               <button
-              onClick={() => setIsOpen(!isOpen)}>
+              onClick={() => { setCulture('leite'); navigate('/dashboard/leite'); setIsOpen(!isOpen); }}>
                 <img src={leite} className='w-12 h-12 hover:w-20 hover:h-20' />
               </button>
           </div>

--- a/src/contexts/culture-context.jsx
+++ b/src/contexts/culture-context.jsx
@@ -1,0 +1,21 @@
+import { createContext, useState } from 'react';
+import PropTypes from 'prop-types';
+
+export const CultureContext = createContext({
+  culture: 'boi',
+  setCulture: () => {},
+});
+
+export const CultureProvider = ({ children }) => {
+  const [culture, setCulture] = useState('boi');
+
+  return (
+    <CultureContext.Provider value={{ culture, setCulture }}>
+      {children}
+    </CultureContext.Provider>
+  );
+};
+
+CultureProvider.propTypes = {
+  children: PropTypes.node,
+};

--- a/src/features/boi/dashboard.jsx
+++ b/src/features/boi/dashboard.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useState, useRef } from 'react';
+import anychart from 'anychart';
+import { Factory, FileText, Handshake, Beef, DollarSign } from 'lucide-react';
+import CountUp from 'react-countup';
+
+const DashboardPage = () => {
+  const [loading, setLoading] = useState(true);
+  const [total, setTotal] = useState(null);
+  const [porData, setPorData] = useState(null);
+  const [error, setError] = useState(null);
+
+  const chartContainerRef = useRef(null);
+  const chartRef = useRef(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(
+          'https://pecuaria.datagro.com/backoffice-pec/api/v1/dashboard/resumo?obter=resumo'
+        );
+        if (!response.ok) throw new Error('Erro ao carregar dados');
+        const data = await response.json();
+        setTotal(data.total);
+        setPorData(data.porData);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const chartData = porData
+    ? Object.entries(porData)
+        .filter(([ano]) => parseInt(ano) >= 2000)
+        .sort(([a], [b]) => parseInt(a) - parseInt(b))
+        .map(([ano, valores]) => ({
+          ano,
+          qtdNegocios: parseInt(valores.qtdNegocios),
+          totalCabecas: parseInt(valores.totalCabecas),
+          total: parseFloat(valores.total),
+        }))
+    : [];
+
+  const formatValorLabel = (valor) => {
+    const num = parseFloat(valor);
+    if (num >= 1_000_000_000_000) return `${(num / 1_000_000_000_000).toFixed(2)} tri`;
+    if (num >= 1_000_000_000) return `${(num / 1_000_000_000).toFixed(2)} bi`;
+    if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(2)} mi`;
+    if (num >= 1_000) return `${(num / 1_000).toFixed(0)} mil`;
+    return `${num}`;
+  };
+
+  const formatValorLabelChart = (valor) => formatValorLabel(valor);
+
+  const formatMoney = (valor) => {
+    const num = parseFloat(valor);
+    if (num >= 1_000_000_000_000) return `R$ ${(num / 1_000_000_000_000).toFixed(2)} tri`;
+    if (num >= 1_000_000_000) return `R$ ${(num / 1_000_000_000).toFixed(2)} bi`;
+    if (num >= 1_000_000) return `R$ ${(num / 1_000_000).toFixed(2)} mi`;
+    if (num >= 1_000) return `R$ ${(num / 1_000).toFixed(0)} mil`;
+    return `R$ ${num}`;
+  };
+
+  useEffect(() => {
+    if (chartContainerRef.current && chartData.length > 0) {
+      if (!chartRef.current) {
+        const chart = anychart.column();
+        chart.background().fill('#2A3529');
+        chart.title('Histórico Comparativo por Ano');
+        chart.xAxis().title('Ano');
+        chart.yAxis().title('Valores');
+        chart.yAxis().labels().format(function () {
+          return formatValorLabelChart(this.value);
+        });
+        chart.tooltip().format('Ano: {%x}\n{%SeriesName}: {%Value}');
+        chart.legend(true);
+        chart.palette(['#4ade80', '#60a5fa', '#facc15']);
+        chart.yScale('log');
+        chart.container(chartContainerRef.current);
+        chartRef.current = chart;
+      }
+
+      const chart = chartRef.current;
+      chart.removeAllSeries();
+
+      const seriesNegocios = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.qtdNegocios }))
+      );
+      seriesNegocios.name('Qtd Negócios');
+      seriesNegocios.labels().enabled(true).format(function () {
+        return formatValorLabel(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      const seriesCabecas = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.totalCabecas }))
+      );
+      seriesCabecas.name('Total Cabeças');
+      seriesCabecas.labels().enabled(true).format(function () {
+        return formatValorLabel(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      const seriesTotal = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.total }))
+      );
+      seriesTotal.name('Total (R$)');
+      seriesTotal.labels().enabled(true).format(function () {
+        return formatMoney(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      chart.draw();
+    }
+  }, [chartData]);
+
+  const formatNumber = (value) =>
+    parseFloat(value).toLocaleString('pt-BR', { maximumFractionDigits: 2 });
+
+  const cards = total
+    ? [
+        { title: 'Indústrias', rawValue: total.qtdIndustrias, icon: Factory, format: formatNumber },
+        { title: 'Arquivos', rawValue: total.qtdArquivos, icon: FileText, format: formatNumber },
+        { title: 'Negócios', rawValue: total.qtdNegocios, icon: Handshake, format: formatNumber },
+        { title: 'Cabeças', rawValue: total.qtdCabecas, icon: Beef, format: formatNumber },
+        { title: 'Total (R$)', rawValue: total.total, icon: DollarSign, format: (v) => `R$ ${formatNumber(v)}` },
+      ]
+    : [];
+
+  if (loading) return <div className="text-white">Carregando...</div>;
+  if (error) return <div className="text-red-500">Erro: {error}</div>;
+  if (!total || !porData) return <div className="text-gray-400">Nenhum dado disponível</div>;
+
+  return (
+    <div className="p-4 bg-primary text-white">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 mb-8">
+        {cards.map((card, index) => (
+          <div
+            key={index}
+            className="bg-card-bg rounded-xl p-4 flex flex-col gap-4 w-full hover:bg-[#1f441d] transition"
+          >
+            <div className="flex items-center gap-3">
+              <div className="bg-quaternary p-2 rounded-lg">
+                <card.icon size={24} className="text-text-bold-color" />
+              </div>
+              <h3 className="text-white text-lg">{card.title}</h3>
+            </div>
+            <div className="bg-quaternary rounded-lg p-4 text-2xl font-bold text-white flex items-center justify-center whitespace-nowrap">
+              <CountUp
+                end={parseFloat(card.rawValue)}
+                duration={1.5}
+                separator="."
+                decimals={2}
+                decimal=","
+                formattingFn={(val) => card.format(val)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        ref={chartContainerRef}
+        style={{
+          width: '100%',
+          height: '500px',
+          borderRadius: '12px',
+          padding: '16px'
+        }}
+      />
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/src/features/etanol/dashboard.jsx
+++ b/src/features/etanol/dashboard.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useState, useRef } from 'react';
+import anychart from 'anychart';
+import { Factory, FileText, Handshake, Beef, DollarSign } from 'lucide-react';
+import CountUp from 'react-countup';
+
+const DashboardPage = () => {
+  const [loading, setLoading] = useState(true);
+  const [total, setTotal] = useState(null);
+  const [porData, setPorData] = useState(null);
+  const [error, setError] = useState(null);
+
+  const chartContainerRef = useRef(null);
+  const chartRef = useRef(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(
+          'https://pecuaria.datagro.com/backoffice-pec/api/v1/dashboard/resumo?obter=resumo'
+        );
+        if (!response.ok) throw new Error('Erro ao carregar dados');
+        const data = await response.json();
+        setTotal(data.total);
+        setPorData(data.porData);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const chartData = porData
+    ? Object.entries(porData)
+        .filter(([ano]) => parseInt(ano) >= 2000)
+        .sort(([a], [b]) => parseInt(a) - parseInt(b))
+        .map(([ano, valores]) => ({
+          ano,
+          qtdNegocios: parseInt(valores.qtdNegocios),
+          totalCabecas: parseInt(valores.totalCabecas),
+          total: parseFloat(valores.total),
+        }))
+    : [];
+
+  const formatValorLabel = (valor) => {
+    const num = parseFloat(valor);
+    if (num >= 1_000_000_000_000) return `${(num / 1_000_000_000_000).toFixed(2)} tri`;
+    if (num >= 1_000_000_000) return `${(num / 1_000_000_000).toFixed(2)} bi`;
+    if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(2)} mi`;
+    if (num >= 1_000) return `${(num / 1_000).toFixed(0)} mil`;
+    return `${num}`;
+  };
+
+  const formatValorLabelChart = (valor) => formatValorLabel(valor);
+
+  const formatMoney = (valor) => {
+    const num = parseFloat(valor);
+    if (num >= 1_000_000_000_000) return `R$ ${(num / 1_000_000_000_000).toFixed(2)} tri`;
+    if (num >= 1_000_000_000) return `R$ ${(num / 1_000_000_000).toFixed(2)} bi`;
+    if (num >= 1_000_000) return `R$ ${(num / 1_000_000).toFixed(2)} mi`;
+    if (num >= 1_000) return `R$ ${(num / 1_000).toFixed(0)} mil`;
+    return `R$ ${num}`;
+  };
+
+  useEffect(() => {
+    if (chartContainerRef.current && chartData.length > 0) {
+      if (!chartRef.current) {
+        const chart = anychart.column();
+        chart.background().fill('#2A3529');
+        chart.title('Histórico Comparativo por Ano');
+        chart.xAxis().title('Ano');
+        chart.yAxis().title('Valores');
+        chart.yAxis().labels().format(function () {
+          return formatValorLabelChart(this.value);
+        });
+        chart.tooltip().format('Ano: {%x}\n{%SeriesName}: {%Value}');
+        chart.legend(true);
+        chart.palette(['#4ade80', '#60a5fa', '#facc15']);
+        chart.yScale('log');
+        chart.container(chartContainerRef.current);
+        chartRef.current = chart;
+      }
+
+      const chart = chartRef.current;
+      chart.removeAllSeries();
+
+      const seriesNegocios = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.qtdNegocios }))
+      );
+      seriesNegocios.name('Qtd Negócios');
+      seriesNegocios.labels().enabled(true).format(function () {
+        return formatValorLabel(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      const seriesCabecas = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.totalCabecas }))
+      );
+      seriesCabecas.name('Total Cabeças');
+      seriesCabecas.labels().enabled(true).format(function () {
+        return formatValorLabel(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      const seriesTotal = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.total }))
+      );
+      seriesTotal.name('Total (R$)');
+      seriesTotal.labels().enabled(true).format(function () {
+        return formatMoney(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      chart.draw();
+    }
+  }, [chartData]);
+
+  const formatNumber = (value) =>
+    parseFloat(value).toLocaleString('pt-BR', { maximumFractionDigits: 2 });
+
+  const cards = total
+    ? [
+        { title: 'Indústrias', rawValue: total.qtdIndustrias, icon: Factory, format: formatNumber },
+        { title: 'Arquivos', rawValue: total.qtdArquivos, icon: FileText, format: formatNumber },
+        { title: 'Negócios', rawValue: total.qtdNegocios, icon: Handshake, format: formatNumber },
+        { title: 'Cabeças', rawValue: total.qtdCabecas, icon: Beef, format: formatNumber },
+        { title: 'Total (R$)', rawValue: total.total, icon: DollarSign, format: (v) => `R$ ${formatNumber(v)}` },
+      ]
+    : [];
+
+  if (loading) return <div className="text-white">Carregando...</div>;
+  if (error) return <div className="text-red-500">Erro: {error}</div>;
+  if (!total || !porData) return <div className="text-gray-400">Nenhum dado disponível</div>;
+
+  return (
+    <div className="p-4 bg-etanol-primary text-white">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 mb-8">
+        {cards.map((card, index) => (
+          <div
+            key={index}
+            className="bg-card-bg rounded-xl p-4 flex flex-col gap-4 w-full hover:bg-[#1f441d] transition"
+          >
+            <div className="flex items-center gap-3">
+              <div className="bg-quaternary p-2 rounded-lg">
+                <card.icon size={24} className="text-text-bold-color" />
+              </div>
+              <h3 className="text-white text-lg">{card.title}</h3>
+            </div>
+            <div className="bg-quaternary rounded-lg p-4 text-2xl font-bold text-white flex items-center justify-center whitespace-nowrap">
+              <CountUp
+                end={parseFloat(card.rawValue)}
+                duration={1.5}
+                separator="."
+                decimals={2}
+                decimal=","
+                formattingFn={(val) => card.format(val)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        ref={chartContainerRef}
+        style={{
+          width: '100%',
+          height: '500px',
+          borderRadius: '12px',
+          padding: '16px'
+        }}
+      />
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/src/features/leite/dashboard.jsx
+++ b/src/features/leite/dashboard.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useState, useRef } from 'react';
+import anychart from 'anychart';
+import { Factory, FileText, Handshake, Beef, DollarSign } from 'lucide-react';
+import CountUp from 'react-countup';
+
+const DashboardPage = () => {
+  const [loading, setLoading] = useState(true);
+  const [total, setTotal] = useState(null);
+  const [porData, setPorData] = useState(null);
+  const [error, setError] = useState(null);
+
+  const chartContainerRef = useRef(null);
+  const chartRef = useRef(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(
+          'https://pecuaria.datagro.com/backoffice-pec/api/v1/dashboard/resumo?obter=resumo'
+        );
+        if (!response.ok) throw new Error('Erro ao carregar dados');
+        const data = await response.json();
+        setTotal(data.total);
+        setPorData(data.porData);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const chartData = porData
+    ? Object.entries(porData)
+        .filter(([ano]) => parseInt(ano) >= 2000)
+        .sort(([a], [b]) => parseInt(a) - parseInt(b))
+        .map(([ano, valores]) => ({
+          ano,
+          qtdNegocios: parseInt(valores.qtdNegocios),
+          totalCabecas: parseInt(valores.totalCabecas),
+          total: parseFloat(valores.total),
+        }))
+    : [];
+
+  const formatValorLabel = (valor) => {
+    const num = parseFloat(valor);
+    if (num >= 1_000_000_000_000) return `${(num / 1_000_000_000_000).toFixed(2)} tri`;
+    if (num >= 1_000_000_000) return `${(num / 1_000_000_000).toFixed(2)} bi`;
+    if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(2)} mi`;
+    if (num >= 1_000) return `${(num / 1_000).toFixed(0)} mil`;
+    return `${num}`;
+  };
+
+  const formatValorLabelChart = (valor) => formatValorLabel(valor);
+
+  const formatMoney = (valor) => {
+    const num = parseFloat(valor);
+    if (num >= 1_000_000_000_000) return `R$ ${(num / 1_000_000_000_000).toFixed(2)} tri`;
+    if (num >= 1_000_000_000) return `R$ ${(num / 1_000_000_000).toFixed(2)} bi`;
+    if (num >= 1_000_000) return `R$ ${(num / 1_000_000).toFixed(2)} mi`;
+    if (num >= 1_000) return `R$ ${(num / 1_000).toFixed(0)} mil`;
+    return `R$ ${num}`;
+  };
+
+  useEffect(() => {
+    if (chartContainerRef.current && chartData.length > 0) {
+      if (!chartRef.current) {
+        const chart = anychart.column();
+        chart.background().fill('#2A3529');
+        chart.title('Histórico Comparativo por Ano');
+        chart.xAxis().title('Ano');
+        chart.yAxis().title('Valores');
+        chart.yAxis().labels().format(function () {
+          return formatValorLabelChart(this.value);
+        });
+        chart.tooltip().format('Ano: {%x}\n{%SeriesName}: {%Value}');
+        chart.legend(true);
+        chart.palette(['#4ade80', '#60a5fa', '#facc15']);
+        chart.yScale('log');
+        chart.container(chartContainerRef.current);
+        chartRef.current = chart;
+      }
+
+      const chart = chartRef.current;
+      chart.removeAllSeries();
+
+      const seriesNegocios = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.qtdNegocios }))
+      );
+      seriesNegocios.name('Qtd Negócios');
+      seriesNegocios.labels().enabled(true).format(function () {
+        return formatValorLabel(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      const seriesCabecas = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.totalCabecas }))
+      );
+      seriesCabecas.name('Total Cabeças');
+      seriesCabecas.labels().enabled(true).format(function () {
+        return formatValorLabel(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      const seriesTotal = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.total }))
+      );
+      seriesTotal.name('Total (R$)');
+      seriesTotal.labels().enabled(true).format(function () {
+        return formatMoney(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      chart.draw();
+    }
+  }, [chartData]);
+
+  const formatNumber = (value) =>
+    parseFloat(value).toLocaleString('pt-BR', { maximumFractionDigits: 2 });
+
+  const cards = total
+    ? [
+        { title: 'Indústrias', rawValue: total.qtdIndustrias, icon: Factory, format: formatNumber },
+        { title: 'Arquivos', rawValue: total.qtdArquivos, icon: FileText, format: formatNumber },
+        { title: 'Negócios', rawValue: total.qtdNegocios, icon: Handshake, format: formatNumber },
+        { title: 'Cabeças', rawValue: total.qtdCabecas, icon: Beef, format: formatNumber },
+        { title: 'Total (R$)', rawValue: total.total, icon: DollarSign, format: (v) => `R$ ${formatNumber(v)}` },
+      ]
+    : [];
+
+  if (loading) return <div className="text-white">Carregando...</div>;
+  if (error) return <div className="text-red-500">Erro: {error}</div>;
+  if (!total || !porData) return <div className="text-gray-400">Nenhum dado disponível</div>;
+
+  return (
+    <div className="p-4 bg-leite-primary text-white">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 mb-8">
+        {cards.map((card, index) => (
+          <div
+            key={index}
+            className="bg-card-bg rounded-xl p-4 flex flex-col gap-4 w-full hover:bg-[#1f441d] transition"
+          >
+            <div className="flex items-center gap-3">
+              <div className="bg-quaternary p-2 rounded-lg">
+                <card.icon size={24} className="text-text-bold-color" />
+              </div>
+              <h3 className="text-white text-lg">{card.title}</h3>
+            </div>
+            <div className="bg-quaternary rounded-lg p-4 text-2xl font-bold text-white flex items-center justify-center whitespace-nowrap">
+              <CountUp
+                end={parseFloat(card.rawValue)}
+                duration={1.5}
+                separator="."
+                decimals={2}
+                decimal=","
+                formattingFn={(val) => card.format(val)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        ref={chartContainerRef}
+        style={{
+          width: '100%',
+          height: '500px',
+          borderRadius: '12px',
+          padding: '16px'
+        }}
+      />
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/src/features/milho/dashboard.jsx
+++ b/src/features/milho/dashboard.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useState, useRef } from 'react';
+import anychart from 'anychart';
+import { Factory, FileText, Handshake, Beef, DollarSign } from 'lucide-react';
+import CountUp from 'react-countup';
+
+const DashboardPage = () => {
+  const [loading, setLoading] = useState(true);
+  const [total, setTotal] = useState(null);
+  const [porData, setPorData] = useState(null);
+  const [error, setError] = useState(null);
+
+  const chartContainerRef = useRef(null);
+  const chartRef = useRef(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(
+          'https://pecuaria.datagro.com/backoffice-pec/api/v1/dashboard/resumo?obter=resumo'
+        );
+        if (!response.ok) throw new Error('Erro ao carregar dados');
+        const data = await response.json();
+        setTotal(data.total);
+        setPorData(data.porData);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const chartData = porData
+    ? Object.entries(porData)
+        .filter(([ano]) => parseInt(ano) >= 2000)
+        .sort(([a], [b]) => parseInt(a) - parseInt(b))
+        .map(([ano, valores]) => ({
+          ano,
+          qtdNegocios: parseInt(valores.qtdNegocios),
+          totalCabecas: parseInt(valores.totalCabecas),
+          total: parseFloat(valores.total),
+        }))
+    : [];
+
+  const formatValorLabel = (valor) => {
+    const num = parseFloat(valor);
+    if (num >= 1_000_000_000_000) return `${(num / 1_000_000_000_000).toFixed(2)} tri`;
+    if (num >= 1_000_000_000) return `${(num / 1_000_000_000).toFixed(2)} bi`;
+    if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(2)} mi`;
+    if (num >= 1_000) return `${(num / 1_000).toFixed(0)} mil`;
+    return `${num}`;
+  };
+
+  const formatValorLabelChart = (valor) => formatValorLabel(valor);
+
+  const formatMoney = (valor) => {
+    const num = parseFloat(valor);
+    if (num >= 1_000_000_000_000) return `R$ ${(num / 1_000_000_000_000).toFixed(2)} tri`;
+    if (num >= 1_000_000_000) return `R$ ${(num / 1_000_000_000).toFixed(2)} bi`;
+    if (num >= 1_000_000) return `R$ ${(num / 1_000_000).toFixed(2)} mi`;
+    if (num >= 1_000) return `R$ ${(num / 1_000).toFixed(0)} mil`;
+    return `R$ ${num}`;
+  };
+
+  useEffect(() => {
+    if (chartContainerRef.current && chartData.length > 0) {
+      if (!chartRef.current) {
+        const chart = anychart.column();
+        chart.background().fill('#2A3529');
+        chart.title('Histórico Comparativo por Ano');
+        chart.xAxis().title('Ano');
+        chart.yAxis().title('Valores');
+        chart.yAxis().labels().format(function () {
+          return formatValorLabelChart(this.value);
+        });
+        chart.tooltip().format('Ano: {%x}\n{%SeriesName}: {%Value}');
+        chart.legend(true);
+        chart.palette(['#4ade80', '#60a5fa', '#facc15']);
+        chart.yScale('log');
+        chart.container(chartContainerRef.current);
+        chartRef.current = chart;
+      }
+
+      const chart = chartRef.current;
+      chart.removeAllSeries();
+
+      const seriesNegocios = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.qtdNegocios }))
+      );
+      seriesNegocios.name('Qtd Negócios');
+      seriesNegocios.labels().enabled(true).format(function () {
+        return formatValorLabel(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      const seriesCabecas = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.totalCabecas }))
+      );
+      seriesCabecas.name('Total Cabeças');
+      seriesCabecas.labels().enabled(true).format(function () {
+        return formatValorLabel(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      const seriesTotal = chart.column(
+        chartData.map((d) => ({ x: d.ano, value: d.total }))
+      );
+      seriesTotal.name('Total (R$)');
+      seriesTotal.labels().enabled(true).format(function () {
+        return formatMoney(this.value);
+      }).fontSize(14).fontWeight('bold').fontColor('#ffffff').position('top');
+
+      chart.draw();
+    }
+  }, [chartData]);
+
+  const formatNumber = (value) =>
+    parseFloat(value).toLocaleString('pt-BR', { maximumFractionDigits: 2 });
+
+  const cards = total
+    ? [
+        { title: 'Indústrias', rawValue: total.qtdIndustrias, icon: Factory, format: formatNumber },
+        { title: 'Arquivos', rawValue: total.qtdArquivos, icon: FileText, format: formatNumber },
+        { title: 'Negócios', rawValue: total.qtdNegocios, icon: Handshake, format: formatNumber },
+        { title: 'Cabeças', rawValue: total.qtdCabecas, icon: Beef, format: formatNumber },
+        { title: 'Total (R$)', rawValue: total.total, icon: DollarSign, format: (v) => `R$ ${formatNumber(v)}` },
+      ]
+    : [];
+
+  if (loading) return <div className="text-white">Carregando...</div>;
+  if (error) return <div className="text-red-500">Erro: {error}</div>;
+  if (!total || !porData) return <div className="text-gray-400">Nenhum dado disponível</div>;
+
+  return (
+    <div className="p-4 bg-milho-primary text-white">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 mb-8">
+        {cards.map((card, index) => (
+          <div
+            key={index}
+            className="bg-card-bg rounded-xl p-4 flex flex-col gap-4 w-full hover:bg-[#1f441d] transition"
+          >
+            <div className="flex items-center gap-3">
+              <div className="bg-quaternary p-2 rounded-lg">
+                <card.icon size={24} className="text-text-bold-color" />
+              </div>
+              <h3 className="text-white text-lg">{card.title}</h3>
+            </div>
+            <div className="bg-quaternary rounded-lg p-4 text-2xl font-bold text-white flex items-center justify-center whitespace-nowrap">
+              <CountUp
+                end={parseFloat(card.rawValue)}
+                duration={1.5}
+                separator="."
+                decimals={2}
+                decimal=","
+                formattingFn={(val) => card.format(val)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        ref={chartContainerRef}
+        style={{
+          width: '100%',
+          height: '500px',
+          borderRadius: '12px',
+          padding: '16px'
+        }}
+      />
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/src/pages/dashboard/boi.jsx
+++ b/src/pages/dashboard/boi.jsx
@@ -1,0 +1,4 @@
+import Dashboard from '@/features/boi/dashboard';
+export default function BoiDashboardPage() {
+  return <Dashboard />;
+}

--- a/src/pages/dashboard/etanol.jsx
+++ b/src/pages/dashboard/etanol.jsx
@@ -1,0 +1,4 @@
+import Dashboard from '@/features/etanol/dashboard';
+export default function EtanolDashboardPage() {
+  return <Dashboard />;
+}

--- a/src/pages/dashboard/leite.jsx
+++ b/src/pages/dashboard/leite.jsx
@@ -1,0 +1,4 @@
+import Dashboard from '@/features/leite/dashboard';
+export default function LeiteDashboardPage() {
+  return <Dashboard />;
+}

--- a/src/pages/dashboard/milho.jsx
+++ b/src/pages/dashboard/milho.jsx
@@ -1,0 +1,4 @@
+import Dashboard from '@/features/milho/dashboard';
+export default function MilhoDashboardPage() {
+  return <Dashboard />;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,21 @@ export default {
         'button-bg': '#394B74',
         'button-hover-bg': '#FFD700',
         'labels': '#F5F5DC',
+        milho: {
+          primary: '#FFD700',
+          secondary: '#FFA500',
+          accent: '#228B22',
+        },
+        leite: {
+          primary: '#ADD8E6',
+          secondary: '#FFFFFF',
+          accent: '#228B22',
+        },
+        etanol: {
+          primary: '#1A1F1A',
+          secondary: '#FFFFFF',
+          accent: '#228B22',
+        },
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],


### PR DESCRIPTION
## Summary
- wire up color palettes for new cultures
- update dashboard pages for Milho, Leite and Etanol to use their colors
- keep CultureProvider wrapping the app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687cff14d4108330a671774c26466706